### PR TITLE
remove  extra </div> in 'merge CAD-101 to dev'

### DIFF
--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -15,7 +15,6 @@
           />
         </div>
       </div>
-    </div>
 
     <div class="row no-gutter">
       <!-- Location Selection -->


### PR DESCRIPTION
This is a new pull request based on the original 'merge CAD-101 to dev' PR that I was reviewing in which I accidentally completed the merge with a breaking error. It's a single '</div>' difference, unfortunately i could not amend it to the original PR I had to revert